### PR TITLE
Fix: Updates latest migration to unblock future ones.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /views/
 .env
 lcov.info
+*.swp

--- a/migrations/sqls/20180801105638-remove-unused-tables-up.sql
+++ b/migrations/sqls/20180801105638-remove-unused-tables-up.sql
@@ -1,5 +1,37 @@
+
+drop function if exists permit.updateUserSequence();
+
+create function permit.updateUserSequence() returns void as
+$$
+
+begin
+
+  if exists (
+    select schema_name
+    from information_schema.schemata
+    where schema_name = 'idm'
+  )
+  then
+    create sequence if not exists idm.users_id_seq
+    start 100000
+    owned by idm.users.user_id;
+
+    alter table idm.users
+       alter column user_id set default nextval('idm.users_id_seq');
+  end if;
+
+end;
+$$ LANGUAGE plpgsql;
+
+select permit.updateUserSequence();
+
 drop table if exists permit.x_licence_shortcode;
+drop table if exists permit.user_licence;
 drop table if exists permit.x_user_licence;
+drop table if exists permit.users;
 drop table if exists permit.x_users;
 drop table if exists permit.licence_data;
 drop table if exists permit.licence_shortcode;
+
+drop function permit.updateUserSequence();
+


### PR DESCRIPTION
The migration was meant originally to delete some unused tables from the
permit schema.

When run on non local environments this migration fails because the
sequence in the `permit.x_users` table is shared with the `idm.users`
table.

So this fix creates a new sequence for `idm.users` which then allows the
other tables to be deleted.

For safety the new sequence starts at 100000.