### PR TITLE
Correctly set NODE_ENV

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,5 @@
-const isAcceptanceTestTarget = ['local', 'dev', 'development', 'test', 'qa', 'preprod'].includes(process.env.NODE_ENV)
+const environment = process.env.ENVIRONMENT
+const isProduction = environment === 'prd'
 
 module.exports = {
 
@@ -20,7 +21,7 @@ module.exports = {
 
   pg: {
     connectionString: process.env.DATABASE_URL,
-    max: process.env.NODE_ENV === 'local' ? 16 : 6,
+    max: 6,
     idleTimeoutMillis: 10000,
     connectionTimeoutMillis: 5000
   },
@@ -37,5 +38,5 @@ module.exports = {
     typeId: 8
   },
 
-  isAcceptanceTestTarget
+  isProduction
 }

--- a/src/routes/API.js
+++ b/src/routes/API.js
@@ -27,7 +27,7 @@ const routes = [
   ...licenceRoutes
 ]
 
-if (config.isAcceptanceTestTarget) {
+if (!config.isProduction) {
   routes.push({
     method: 'DELETE',
     path: `/API/${version}/acceptance-tests`,


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/43

We are currently using `NODE_ENV` incorrectly; we set it to be the name of the specific environment (eg. `local`, `qa` etc.) when it should be more like the _type_ of environment (eg. is it a dev environment, a production environment, etc.)

This means that tools like pm2 aren't correctly picking up that we are running in a dev-like or prod-like environment and configuring accordingly.

We, therefore, change how we use `NODE_ENV` to be the type of environment, with a separate `ENVIRONMENT` env var to set the actual environment (eg. `tst`, `pre` etc.)