### PR TITLE
Stop passing err to logger.error

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ async function start () {
 }
 
 const processError = message => err => {
-  logger.error(message, err)
+  logger.error(message, err.stack)
   process.exit(1)
 }
 


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/45

Here we are trying to make the error logs more usable. Currently when an error happens the logs are getting jammed up with thousands of lines making them difficult to read and unusable. This change stops that pollution making them more usable.