### PR TITLE
Start doing the minimum in /status checks

### DIFF
--- a/src/lib/controllers/status.js
+++ b/src/lib/controllers/status.js
@@ -1,5 +1,9 @@
-const pkg = require('../../../package.json')
+'use strict'
 
-const statusResponse = { version: pkg.version }
+function getStatus () {
+  return { status: 'alive' }
+}
 
-exports.getStatus = () => statusResponse
+module.exports = {
+  getStatus
+}

--- a/test/lib/controllers/status.test.js
+++ b/test/lib/controllers/status.test.js
@@ -4,9 +4,9 @@ const controller = require('../../../src/lib/controllers/status')
 
 experiment('statusController', () => {
   experiment('getStatus', () => {
-    test('returns an object with the application version', () => {
+    test('returns an object with the application status', () => {
       const response = controller.getStatus()
-      expect(response.version).to.match(/^\d*\.\d*.\d*$/)
+      expect(response.status).to.equal('alive')
     })
   })
 })

--- a/test/lib/controllers/status.test.js
+++ b/test/lib/controllers/status.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test, experiment } = exports.lab = require('@hapi/lab').script()
 const { expect } = require('@hapi/code')
 const controller = require('../../../src/lib/controllers/status')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4096

AWS ELBs require an endpoint they can hit to confirm whether an app is running. They are commonly referred to as health checks and are used to determine whether the ELB should route traffic through to an app instance. In our apps, it is the `/status` endpoint.

The endpoint in all our repos currently reads in the `package.json` file to get the app's version number. This information is then used to support the `/service-status` page in the water-abstraction-ui. Some of the repos also include a test query to the DB to confirm it can connect.

Having checks that confirm you can connect to dependent services (databases, other apps etc) is a good thing. But the ELB health checks are made multiple times a second across all instances. They only care whether an app is up or not. So if, for example, you include querying your DB in  `/status` you're hitting your DB with multiple connections per second, multiplied by the number of server instances you have running.

Including reading a file from disk each time means we're adding an unnecessary load on a service that already has performance and resource usage issues.

We've already added a new `/health/info` endpoint to each repo and we do DB connection checks elsewhere. So, we can reduce the work of our `/status` endpoint across all the repos to the bare minimum; returning a static `{ "status": "alive" }` response.

This issue was originally raised in https://github.com/DEFRA/water-abstraction-team/issues/67