### PR TITLE
Removing console.log() from legacy migrations

### DIFF
--- a/migrations/20171201101816-permits.js
+++ b/migrations/20171201101816-permits.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20171212143755-permit-upsert.js
+++ b/migrations/20171212143755-permit-upsert.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180124105800-add-licences-licence-data.js
+++ b/migrations/20180124105800-add-licences-licence-data.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180124132546-copy-licence-data.js
+++ b/migrations/20180124132546-copy-licence-data.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180212081709-jsonb.js
+++ b/migrations/20180212081709-jsonb.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180213141329-add-expiring-view.js
+++ b/migrations/20180213141329-add-expiring-view.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180216081218-adjust-expiry-view.js
+++ b/migrations/20180216081218-adjust-expiry-view.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180216135624-adjust-expiry-view-again.js
+++ b/migrations/20180216135624-adjust-expiry-view-again.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180525130013-permit-metadata.js
+++ b/migrations/20180525130013-permit-metadata.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20180801105638-remove-unused-tables.js
+++ b/migrations/20180801105638-remove-unused-tables.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20190920125542-remove-expiring-licence-view.js
+++ b/migrations/20190920125542-remove-expiring-licence-view.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20210625125916-change-hydrology-guid-to-wrls-guid.js
+++ b/migrations/20210625125916-change-hydrology-guid-to-wrls-guid.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })

--- a/migrations/20210812080321-add-missing-cols.js
+++ b/migrations/20210812080321-add-missing-cols.js
@@ -17,7 +17,6 @@ exports.up = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })
@@ -32,7 +31,6 @@ exports.down = function (db) {
   return new Promise(function (resolve, reject) {
     fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
       if (err) return reject(err)
-      console.log('received data: ' + data)
 
       resolve(data)
     })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/91

This PR is focusing on removing console.log() from legacy migrations as per Teams issue. When working on DEFRA/water-abstraction-service#2227 we again broke GitHub CI because of the volume of output from our migrations.

In DEFRA/water-abstraction-team#65 we thought we'd dealt with the issue believing that db-mgrate's verbose() argument was to blame.

Looking into the issue in the stuck bill run we came across a db-migrate/node-db-migrate#453 (comment) that gave us a 🤦 !

The db-migrate template used when generating migrations includes a console.log() that outputs the migration file read in. So, though we might not be outputting all the SQL being fired, we are still outputting the contents of every single migration file!

We definitely don't need to see this and it should remove the chance of us breaking the build in this way once and for all.

So, this issue is about going into the existing migrations and removing the 2 console.log('received data: ' + data) lines in each across all repos.